### PR TITLE
[regression] Fix entrypoint to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "tsconfig-paths": "3.9.0",
     "typescript": "3.9.7"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "prettier": {
     "singleQuote": true,
     "trailingComma": "all"


### PR DESCRIPTION
**This was working in 6.0.0-alpha.2**

The module's entrypoint does not reside in `dist`, it is in `lib`. I am not sure if the intention is to have it in `dist` but the only folder included when the module is installed is `lib`. I'm not even sure how it is ending up in `lib` because the [`tsconfig.json` points to `dist`](https://github.com/mentos1386/nest-raven/blob/master/tsconfig.json#L12).

At the moment, this module is not working since node is unable to resolve an entrypoint.

```
❯ node
Welcome to Node.js v12.18.3.
Type ".help" for more information.
> require.resolve("nest-raven")
Uncaught Error: Cannot find module 'nest-raven'
Require stack:
- <repl>
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:965:15)
    at Function.resolve (internal/modules/cjs/helpers.js:78:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '<repl>' ]
}
```

Here is an image of the on-disk structure of this package after installation. 

<img width="254" alt="Screen Shot 2020-08-27 at 3 37 42 PM" src="https://user-images.githubusercontent.com/2791730/91487479-cf042c00-e87b-11ea-83d0-e10d32269a3e.png">
